### PR TITLE
Bump kubo-rpc-client for parse-duration advisory

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "it-first": "^1.0.4",
     "it-last": "^1.0.4",
     "it-to-stream": "^1.0.0",
-    "kubo-rpc-client": "^5.0.2",
+    "kubo-rpc-client": "^6.1.0",
     "libp2p-crypto": "0.19.7",
     "libp2p-interfaces": "1.1.0",
     "lodash": "^4.18.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2152,7 +2152,7 @@
     "@libp2p/logger" "^6.2.6"
     interface-datastore "^9.0.1"
 
-"@libp2p/crypto@^5.0.0", "@libp2p/crypto@^5.0.4":
+"@libp2p/crypto@^5.0.0":
   version "5.0.4"
   resolved "https://registry.yarnpkg.com/@libp2p/crypto/-/crypto-5.0.4.tgz#26f24025f3dd2be959360c6b58c94ccadb04ed63"
   integrity sha512-v5xsngOlDu8JP3GQDvK+2YYzTELl7/aPfXPbIzKEcy7ON2hu79t1BZMuavjPsr+WWIPNg5yKst6IJfRilzwXRQ==
@@ -2294,7 +2294,7 @@
     "@multiformats/multiaddr" "^13.0.1"
     progress-events "^1.0.1"
 
-"@libp2p/interface@^2.0.0", "@libp2p/interface@^2.1.2":
+"@libp2p/interface@^2.1.2":
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/@libp2p/interface/-/interface-2.1.2.tgz#7b38047a7d2d35a6a4e0f0f22fbdeeec98b85321"
   integrity sha512-uD4NapC+1qGX7RmgC1aehQm3pMs1MpO1DwuhUlAo1M6CyNxfs1Ha9jhg2T+G4u4CAJM6wffZTyPGnKnrR+M8Fw==
@@ -2369,17 +2369,6 @@
     sanitize-filename "^1.6.3"
     uint8arrays "^5.1.0"
 
-"@libp2p/logger@^5.0.0":
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/@libp2p/logger/-/logger-5.1.0.tgz#d580e2ee89e3f4224129cc12d727b45494aad6e5"
-  integrity sha512-hmkk1TONYRe+kKs5QTxkayIfj9qicp8hcrJ1Ac9QfTW/jdaUlnqd1uop4QcOD5GV6qNMq+v1qaMFWFYSN9RcPA==
-  dependencies:
-    "@libp2p/interface" "^2.1.2"
-    "@multiformats/multiaddr" "^12.2.3"
-    interface-datastore "^8.3.0"
-    multiformats "^13.1.0"
-    weald "^1.0.2"
-
 "@libp2p/logger@^6.0.4", "@libp2p/logger@^6.0.5", "@libp2p/logger@^6.2.4", "@libp2p/logger@^6.2.6":
   version "6.2.6"
   resolved "https://registry.yarnpkg.com/@libp2p/logger/-/logger-6.2.6.tgz#849d7ac81867d5cb056a9ae63e7d6def29ee11da"
@@ -2438,16 +2427,6 @@
     "@libp2p/peer-id" "^6.0.8"
     "@libp2p/utils" "^7.1.0"
     multiformats "^13.4.0"
-
-"@libp2p/peer-id@^5.0.0":
-  version "5.0.4"
-  resolved "https://registry.yarnpkg.com/@libp2p/peer-id/-/peer-id-5.0.4.tgz#5a71f449b97098a5b12631b6be898a016a82c6bb"
-  integrity sha512-CHNbQ4Odlc+YDTtv6BzWdGSaJ1I3Wb6iHNV7YB59v0ivSsd0NzlR31qWpK/ByUAMT+hfzQzR1dK9s3e7zS4/zQ==
-  dependencies:
-    "@libp2p/crypto" "^5.0.4"
-    "@libp2p/interface" "^2.1.2"
-    multiformats "^13.1.0"
-    uint8arrays "^5.1.0"
 
 "@libp2p/peer-id@^6.0.0", "@libp2p/peer-id@^6.0.3", "@libp2p/peer-id@^6.0.6", "@libp2p/peer-id@^6.0.8":
   version "6.0.8"
@@ -2702,13 +2681,6 @@
   dependencies:
     "@multiformats/multiaddr" "^13.0.0"
 
-"@multiformats/multiaddr-to-uri@^10.0.1":
-  version "10.1.0"
-  resolved "https://registry.yarnpkg.com/@multiformats/multiaddr-to-uri/-/multiaddr-to-uri-10.1.0.tgz#f52312cee11b6ad25997e743d9c575c44726c7d0"
-  integrity sha512-ZNwSAx3ssBWwd4y0LKrOsq9xG7LBHboQxnUdSduNc2fTh/NS1UjA2slgUy6KHxH5k9S2DSus0iU2CoyJyN0/pg==
-  dependencies:
-    "@multiformats/multiaddr" "^12.3.0"
-
 "@multiformats/multiaddr-to-uri@^12.0.0":
   version "12.0.0"
   resolved "https://registry.yarnpkg.com/@multiformats/multiaddr-to-uri/-/multiaddr-to-uri-12.0.0.tgz#312c4eebeee2bf7e32e7d477b6ad4b32d3bceccb"
@@ -2716,7 +2688,7 @@
   dependencies:
     "@multiformats/multiaddr" "^13.0.0"
 
-"@multiformats/multiaddr@^12.2.1", "@multiformats/multiaddr@^12.2.3", "@multiformats/multiaddr@^12.3.0":
+"@multiformats/multiaddr@^12.2.3":
   version "12.3.1"
   resolved "https://registry.yarnpkg.com/@multiformats/multiaddr/-/multiaddr-12.3.1.tgz#953ceb4ae3b39125b7b2c721230ea7b398cf49fe"
   integrity sha512-yoGODQY4nIj41ENJClucS8FtBoe8w682bzbKldEQr9lSlfdHqAsRC+vpJAOBpiMwPps1tHua4kxrDmvprdhoDQ==
@@ -7046,14 +7018,6 @@ interface-blockstore@^6.0.0, interface-blockstore@^6.0.1, interface-blockstore@^
     interface-store "^7.0.0"
     multiformats "^13.4.2"
 
-interface-datastore@^8.3.0:
-  version "8.3.1"
-  resolved "https://registry.yarnpkg.com/interface-datastore/-/interface-datastore-8.3.1.tgz#c793f990c5cf078a24a8a2ded13f7e2099a2a282"
-  integrity sha512-3r0ETmHIi6HmvM5sc09QQiCD3gUfwtEM/AAChOyAd/UAKT69uk8LXfTSUBufbUIO/dU65Vj8nb9O6QjwW8vDSQ==
-  dependencies:
-    interface-store "^6.0.0"
-    uint8arrays "^5.1.0"
-
 interface-datastore@^9.0.0, interface-datastore@^9.0.1, interface-datastore@^9.0.2, interface-datastore@^9.0.3:
   version "9.0.3"
   resolved "https://registry.yarnpkg.com/interface-datastore/-/interface-datastore-9.0.3.tgz#ad181f970cf4756cbe3e416043634f7daaabb86a"
@@ -7061,11 +7025,6 @@ interface-datastore@^9.0.0, interface-datastore@^9.0.1, interface-datastore@^9.0
   dependencies:
     interface-store "^7.0.0"
     uint8arrays "^5.1.0"
-
-interface-store@^6.0.0:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/interface-store/-/interface-store-6.0.2.tgz#1746a1ee07634f7678b3aa778738b79e3f75c909"
-  integrity sha512-KSFCXtBlNoG0hzwNa0RmhHtrdhzexp+S+UY2s0rWTBJyfdEIgn6i6Zl9otVqrcFYbYrneBT7hbmHQ8gE0C3umA==
 
 interface-store@^7.0.0, interface-store@^7.0.2:
   version "7.0.2"
@@ -7139,14 +7098,6 @@ ipfs-unixfs-importer@^16.1.4:
     rabin-wasm "^0.1.5"
     uint8arraylist "^2.4.8"
     uint8arrays "^5.1.0"
-
-ipfs-unixfs@^11.1.4:
-  version "11.2.0"
-  resolved "https://registry.yarnpkg.com/ipfs-unixfs/-/ipfs-unixfs-11.2.0.tgz#a7f3d1f9bce29033f273bda124a0eb8bc0c752f6"
-  integrity sha512-J8FN1qM5nfrDo8sQKQwfj0+brTg1uBfZK2vY9hxci33lcl3BFrsELS9+1+4q/8tO1ASKfxZO8W3Pi2O4sVX2Lg==
-  dependencies:
-    protons-runtime "^5.5.0"
-    uint8arraylist "^2.4.8"
 
 ipfs-unixfs@^12.0.0, ipfs-unixfs@^12.0.1:
   version "12.0.2"
@@ -8049,27 +8000,27 @@ kind-of@^6.0.2, kind-of@^6.0.3:
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
   integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
 
-kubo-rpc-client@^5.0.2:
-  version "5.0.2"
-  resolved "https://registry.yarnpkg.com/kubo-rpc-client/-/kubo-rpc-client-5.0.2.tgz#17d635547139ab2e697bc4ec33bf3c8382209dd2"
-  integrity sha512-0w8VUwpxtkynLlJsAnM+es3qR6Nvv0/oqg0I+sCgI65rh8OPoBYpsk58/miD+u/OkIhJKBwslfeJ9y7Ujb40+g==
+kubo-rpc-client@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/kubo-rpc-client/-/kubo-rpc-client-6.1.0.tgz#046816edf97309c635e22aebb5c7d82d0c573b4f"
+  integrity sha512-CH3vcqSGlEhr/HCZYQgYpXxmwIOYhNed4BQmAYmHpX7sehTC3iKK/36x7anEdRTgmV6KB66MyOk1yuhU2HqKFw==
   dependencies:
     "@ipld/dag-cbor" "^9.0.0"
     "@ipld/dag-json" "^10.0.0"
     "@ipld/dag-pb" "^4.0.0"
     "@libp2p/crypto" "^5.0.0"
-    "@libp2p/interface" "^2.0.0"
-    "@libp2p/logger" "^5.0.0"
-    "@libp2p/peer-id" "^5.0.0"
-    "@multiformats/multiaddr" "^12.2.1"
-    "@multiformats/multiaddr-to-uri" "^10.0.1"
+    "@libp2p/interface" "^3.0.2"
+    "@libp2p/logger" "^6.0.5"
+    "@libp2p/peer-id" "^6.0.3"
+    "@multiformats/multiaddr" "^13.0.1"
+    "@multiformats/multiaddr-to-uri" "^12.0.0"
     any-signal "^4.1.1"
     blob-to-it "^2.0.5"
     browser-readablestream-to-it "^2.0.5"
     dag-jose "^5.0.0"
     electron-fetch "^1.9.1"
     err-code "^3.0.1"
-    ipfs-unixfs "^11.1.4"
+    ipfs-unixfs "^12.0.0"
     iso-url "^1.2.1"
     it-all "^3.0.4"
     it-first "^3.0.4"
@@ -8081,9 +8032,7 @@ kubo-rpc-client@^5.0.2:
     merge-options "^3.0.4"
     multiformats "^13.1.0"
     nanoid "^5.0.7"
-    native-fetch "^4.0.2"
-    parse-duration "^1.0.2"
-    react-native-fetch-api "^3.0.0"
+    parse-duration "^2.1.2"
     stream-to-it "^1.0.1"
     uint8arrays "^5.0.3"
     wherearewe "^2.0.1"
@@ -8990,11 +8939,6 @@ native-fetch@^3.0.0:
   resolved "https://registry.yarnpkg.com/native-fetch/-/native-fetch-3.0.0.tgz#06ccdd70e79e171c365c75117959cf4fe14a09bb"
   integrity sha512-G3Z7vx0IFb/FQ4JxvtqGABsOTIqRWvgQz6e+erkB+JJD6LrszQtMozEHI4EkmgZQvnGHrpLVzUWk7t4sJCIkVw==
 
-native-fetch@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/native-fetch/-/native-fetch-4.0.2.tgz#75c8a44c5f3bb021713e5e24f2846750883e49af"
-  integrity sha512-4QcVlKFtv2EYVS5MBgsGX5+NWKtbDbIECdUXDBGDMAZXq3Jkv9zf+y8iS7Ub8fEdga3GpYeazp9gauNqXHJOCg==
-
 neo-async@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
@@ -9546,10 +9490,10 @@ parallel-transform@^1.1.0:
     inherits "^2.0.3"
     readable-stream "^2.1.5"
 
-parse-duration@^1.0.2:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/parse-duration/-/parse-duration-1.1.0.tgz#5192084c5d8f2a3fd676d04a451dbd2e05a1819c"
-  integrity sha512-z6t9dvSJYaPoQq7quMzdEagSFtpGu+utzHqqxmpVWNNZRIXnvqyCvn9XsTdh7c/w0Bqmdz3RB3YnRaKtpRtEXQ==
+parse-duration@^2.1.2:
+  version "2.1.6"
+  resolved "https://registry.yarnpkg.com/parse-duration/-/parse-duration-2.1.6.tgz#0706b952e20623114facb81e51b1a9df6cfa6e02"
+  integrity sha512-1/A2Exg3NcJGcYdgV/dn4frR7vO2hOW/ohQ4KIgbT4W3raVcpYSszPWiL6I6cKufi4jQM5NbGRXLBj8AoLM4iQ==
 
 parse-github-repo-url@^1.3.0:
   version "1.4.1"
@@ -9887,7 +9831,7 @@ protoduck@^5.0.1:
   dependencies:
     genfun "^5.0.0"
 
-protons-runtime@^5.4.0, protons-runtime@^5.5.0:
+protons-runtime@^5.4.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/protons-runtime/-/protons-runtime-5.5.0.tgz#ea06d9ef843aad77ea5de3e1ebafa81b58c24570"
   integrity sha512-EsALjF9QsrEk6gbCx3lmfHxVN0ah7nG3cY7GySD4xf4g8cr7g543zB88Foh897Sr1RQJ9yDCUsoT1i1H/cVUFA==
@@ -10084,13 +10028,6 @@ rc@^1.2.7:
     ini "~1.3.0"
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
-
-react-native-fetch-api@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/react-native-fetch-api/-/react-native-fetch-api-3.0.0.tgz#81e1bb6562c292521bc4eca52fe1097f4c1ebab5"
-  integrity sha512-g2rtqPjdroaboDKTsJCTlcmtw54E25OjyaunUP0anOZn4Fuo2IKs8BVfe02zVggA/UysbmfSnRJIqtNkAgggNA==
-  dependencies:
-    p-defer "^3.0.0"
 
 react-native-webrtc@^124.0.6:
   version "124.0.7"
@@ -11190,11 +11127,6 @@ supports-color@^8.1.1:
   dependencies:
     has-flag "^4.0.0"
 
-supports-color@^9.4.0:
-  version "9.4.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-9.4.0.tgz#17bfcf686288f531db3dea3215510621ccb55954"
-  integrity sha512-VL+lNrEoIXww1coLPOmiEmK/0sGigko5COxI09KzHc2VJXJsQ37UaQ+8quuxjDeA7+KnLGTWRyOXSLLR2Wb4jw==
-
 supports-preserve-symlinks-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
@@ -11784,14 +11716,6 @@ wcwidth@^1.0.0:
   integrity sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==
   dependencies:
     defaults "^1.0.3"
-
-weald@^1.0.2:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/weald/-/weald-1.0.3.tgz#c3301ae4dcff5d52780893f3b5683f6a8b7ca1ab"
-  integrity sha512-h5pTSGRApQotfZ8Goqe5Jrg6iOjx4uXB55I00A+WRMZbhbiWfUatr6fMLt6UNrURzqXaX/ZDhIvcDzs1TEzz4Q==
-  dependencies:
-    ms "^3.0.0-canary.1"
-    supports-color "^9.4.0"
 
 weald@^1.1.0:
   version "1.1.1"


### PR DESCRIPTION
## Summary
- Closes #128
- Keeps this dependency-security work on the existing dependency branch.
- Bumps `kubo-rpc-client` from `^5.0.2` to `^6.1.0`.
- Refreshes `yarn.lock` so `parse-duration` resolves to `2.1.6` instead of vulnerable `1.1.0`.

## Verification
- `yarn install --ignore-scripts`
- `yarn why parse-duration --json` shows `parse-duration@2.1.6`

## Notes
- `npm install` is blocked locally on Node 22 by an old git dependency path: `ganache-core -> sha3` fails native compilation.
- `npm test` is blocked after the scriptless install because `node-datachannel` native bindings are not built.
- Downstream `geesome-node` still needs its direct `kubo-rpc-client` bump and `geesome-libs` pointer update after this PR lands.
