### PR TITLE
Bump direct node-forge dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "lodash": "^4.18.1",
     "multiformats": "13.3.0",
     "multihashes": "^4.0.2",
-    "node-forge": "1.3.0",
+    "node-forge": "^1.4.0",
     "openpgp": "^4.10.0",
     "p-iteration": "^1.1.8",
     "peer-id": "0.15.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9012,17 +9012,12 @@ node-fetch@~1.7.1:
     encoding "^0.1.11"
     is-stream "^1.0.1"
 
-node-forge@1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.3.0.tgz#37a874ea723855f37db091e6c186e5b67a01d4b2"
-  integrity sha512-08ARB91bUi6zNKzVmaj3QO7cr397uiDT2nJ63cHjyNtCTWIgvS47j3eT0WfzUwS9+6Z5YshRaoasFkXCKrIYbA==
-
 node-forge@^0.10.0:
   version "0.10.0"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.10.0.tgz#32dea2afb3e9926f02ee5ce8794902691a676bf3"
   integrity sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==
 
-node-forge@^1.3.1:
+node-forge@^1.3.1, node-forge@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.4.0.tgz#1c7b7d8bdc2d078739f58287d589d903a11b2fc2"
   integrity sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==


### PR DESCRIPTION
Summary
- closes #130
- bumps the direct node-forge dependency from 1.3.0 to the current 1.4.x patched line
- refreshes yarn.lock so the direct dependency shares the existing node-forge@1.4.0 lock entry

Verification
- yarn add node-forge@^1.4.0
- yarn why node-forge
- node --import tsx --experimental-global-customevent ./node_modules/.bin/mocha 'test/pgp.test.ts'
- git diff --check
- yarn audit --groups dependencies --level high --json | rg "\"module_name\":\"node-forge\"|auditSummary|node-forge" || true

Notes
- Full npm test is currently blocked locally by the missing node-datachannel native module: Cannot find module ../../../build/Release/node_datachannel.node. The forge-dependent pgp test passes.
- Audit still reports node-forge through legacy libp2p-crypto/peer-id at node-forge@0.10.0; that needs the larger libp2p/peer-id migration rather than this direct dependency bump.