### PR TITLE
Patch wallet axios dependency chain

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,9 @@
     "typescript": "4.5.2"
   },
   "resolutions": {
+    "geesome-wallet-client/axios": "1.16.0",
+    "geesome-wallet-client/follow-redirects": "1.16.0",
+    "geesome-wallet-client/**/follow-redirects": "1.16.0",
     "elliptic": "6.6.1",
     "eccrypto/secp256k1": "4.0.4",
     "eth-crypto/**/secp256k1": "4.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3774,14 +3774,7 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.13.2.tgz#0aa167216965ac9474ccfa83892cfb6b3e1e52ef"
   integrity sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==
 
-axios@^0.19.0:
-  version "0.19.2"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.2.tgz#3ea36c5d8818d0d5f8a8a97a6d36b86cdc00cb27"
-  integrity sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==
-  dependencies:
-    follow-redirects "1.5.10"
-
-axios@^1.16.0, axios@^1.7.2:
+axios@1.16.0, axios@^0.19.0, axios@^1.16.0, axios@^1.7.2:
   version "1.16.0"
   resolved "https://registry.yarnpkg.com/axios/-/axios-1.16.0.tgz#f8e5dd931cef2a5f8c32216d5784eda2f8750eb7"
   integrity sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==
@@ -4823,7 +4816,7 @@ dateformat@^3.0.0:
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
   integrity sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==
 
-debug@3.1.0, debug@=3.1.0:
+debug@3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
   integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
@@ -6088,14 +6081,7 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
 
-follow-redirects@1.5.10:
-  version "1.5.10"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
-  integrity sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==
-  dependencies:
-    debug "=3.1.0"
-
-follow-redirects@^1.16.0:
+follow-redirects@1.16.0, follow-redirects@^1.16.0:
   version "1.16.0"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.16.0.tgz#28474a159d3b9d11ef62050a14ed60e4df6d61bc"
   integrity sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==


### PR DESCRIPTION
Summary
- closes #134
- adds Yarn resolutions for the legacy geesome-wallet-client axios path
- consolidates axios to 1.16.0 and follow-redirects to 1.16.0
- refreshes yarn.lock to remove the nested axios@0.19.2 / follow-redirects@1.5.10 copy

Verification
- yarn install
- yarn why axios
- yarn why follow-redirects
- yarn audit --groups dependencies --level high --json | node -e '<targeted parser for axios/follow-redirects advisories>'
- node --import tsx --experimental-global-customevent ./node_modules/.bin/mocha test/ethereum.test.ts
- node --import tsx --experimental-global-customevent -e "await import('./src/web3Manager.ts'); await import('./src/ethereum.ts'); console.log('wallet import smoke ok')"
- git diff --check

Notes
- Yarn warns that axios@1.16.0 overrides geesome-wallet-client's old axios@^0.19.0 request; this is intentional for the patched security resolution.
- Full npm test is currently blocked in this local environment before reaching this change because node-datachannel is missing build/Release/node_datachannel.node.
