### PR TITLE
Patch wallet transitive security batch

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,9 +68,15 @@
     "typescript": "4.5.2"
   },
   "resolutions": {
+    "base-x": "3.0.11",
+    "levelup/semver": "5.7.2",
+    "geesome-wallet-client/**/levelup/semver": "5.7.2",
+    "eth-crypto/ethers/@ethersproject/providers/ws": "7.5.10",
     "geesome-wallet-client/axios": "1.16.0",
     "geesome-wallet-client/follow-redirects": "1.16.0",
     "geesome-wallet-client/**/follow-redirects": "1.16.0",
+    "geesome-wallet-client/ethers/@ethersproject/providers/ws": "7.5.10",
+    "geesome-wallet-client/web3-provider-engine/ws": "5.2.4",
     "elliptic": "6.6.1",
     "eccrypto/secp256k1": "4.0.4",
     "eth-crypto/**/secp256k1": "4.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3827,10 +3827,10 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
-base-x@^3.0.2:
-  version "3.0.10"
-  resolved "https://registry.yarnpkg.com/base-x/-/base-x-3.0.10.tgz#62de58653f8762b5d6f8d9fe30fa75f7b2585a75"
-  integrity sha512-7d0s06rR9rYaIWHkpfLIFICM/tkSVdoPC9qYAQRpxn9DdKNWNsKC0uk++akckyLq16Tx2WIinnZ6WRriAt6njQ==
+base-x@3.0.11, base-x@^3.0.2:
+  version "3.0.11"
+  resolved "https://registry.yarnpkg.com/base-x/-/base-x-3.0.11.tgz#40d80e2a1aeacba29792ccc6c5354806421287ff"
+  integrity sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA==
   dependencies:
     safe-buffer "^5.0.1"
 
@@ -10462,7 +10462,7 @@ semaphore@>=1.0.1, semaphore@^1.0.3:
   resolved "https://registry.yarnpkg.com/semaphore/-/semaphore-1.1.0.tgz#aaad8b86b20fe8e9b32b16dc2ee682a8cd26a8aa"
   integrity sha512-O4OZEaNtkMd/K0i6js9SL+gqy0ZCBMgUvlSqHKi4IBdjhe7wB8pwztUk1BbZ1fmrvpwFrPbHzqd2w5pTcJH6LA==
 
-"semver@2 || 3 || 4 || 5", "semver@2.x || 3.x || 4 || 5", semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0, semver@^5.7.0, semver@^5.7.1:
+"semver@2 || 3 || 4 || 5", "semver@2.x || 3.x || 4 || 5", semver@5.7.2, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0, semver@^5.7.0, semver@^5.7.1, semver@~5.4.1:
   version "5.7.2"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.2.tgz#48d55db737c3287cd4835e17fa13feace1c41ef8"
   integrity sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==
@@ -10476,11 +10476,6 @@ semver@^7.3.4, semver@^7.3.5:
   version "7.6.3"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.3.tgz#980f7b5550bc175fb4dc09403085627f9eb33143"
   integrity sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==
-
-semver@~5.4.1:
-  version "5.4.1"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.4.1.tgz#e059c09d8571f0540823733433505d3a2f00b18e"
-  integrity sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==
 
 serialize-javascript@^6.0.2:
   version "6.0.2"
@@ -11863,22 +11858,17 @@ write-pkg@^3.1.0:
     sort-keys "^2.0.0"
     write-json-file "^2.2.0"
 
-ws@7.2.3:
-  version "7.2.3"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-7.2.3.tgz#a5411e1fb04d5ed0efee76d26d5c46d830c39b46"
-  integrity sha512-HTDl9G9hbkNDk98naoR/cHDws7+EyYMOdL1BmjsZXRUjf7d+MficC4B7HLUPlSiho0vg+CWKrGIt/VJBd1xunQ==
-
-ws@7.4.6:
-  version "7.4.6"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.6.tgz#5654ca8ecdeee47c33a9a4bf6d28e2be2980377c"
-  integrity sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==
-
-ws@^5.1.1:
+ws@5.2.4, ws@^5.1.1:
   version "5.2.4"
   resolved "https://registry.yarnpkg.com/ws/-/ws-5.2.4.tgz#c7bea9f1cfb5f410de50e70e82662e562113f9a7"
   integrity sha512-fFCejsuC8f9kOSu9FYaOw8CdO68O3h5v0lg4p74o8JqWpwTf9tniOD+nOB78aWoVSS6WptVUmDrp/KPsMVBWFQ==
   dependencies:
     async-limiter "~1.0.0"
+
+ws@7.2.3, ws@7.4.6, ws@7.5.10:
+  version "7.5.10"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.10.tgz#58b5c20dc281633f6c19113f39b349bd8bd558d9"
+  integrity sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==
 
 ws@^8.18.3:
   version "8.20.0"


### PR DESCRIPTION
Summary
- closes #136
- pins base-x to 3.0.11 for the Ethereum base58 stack
- pins the old levelup semver path to 5.7.2 without downgrading unrelated semver@6 users
- pins vulnerable ws paths to patched releases by parent line: web3-provider-engine stays on ws@5.2.4, ethers provider paths move to ws@7.5.10
- refreshes yarn.lock

Verification
- yarn install
- yarn why base-x
- yarn why semver
- yarn why ws
- yarn audit --groups dependencies --level high --json | node -e '<targeted parser for base-x/semver/ws advisories>'
- node --import tsx --experimental-global-customevent ./node_modules/.bin/mocha test/ethereum.test.ts
- node --import tsx --experimental-global-customevent -e "await import('./src/web3Manager.ts'); await import('./src/ethereum.ts'); console.log('wallet import smoke ok')"
- git diff --check

Notes
- Yarn warns that the patched ws and semver resolutions override old vulnerable transitive requests; this is intentional and scoped to the affected wallet/Ethereum paths.
- Targeted audit reports zero base-x/semver/ws advisories, and the high audit count dropped from 41 to 37 in this local run.
- Full npm test is currently blocked in this local environment before reaching this change because node-datachannel is missing build/Release/node_datachannel.node.
