### PR TITLE
Patch fetch-ponyfill node-fetch chain

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,8 @@
     "geesome-wallet-client/axios": "1.16.0",
     "geesome-wallet-client/follow-redirects": "1.16.0",
     "geesome-wallet-client/**/follow-redirects": "1.16.0",
+    "geesome-wallet-client/**/fetch-ponyfill/node-fetch": "2.7.0",
+    "fetch-ponyfill/node-fetch": "2.7.0",
     "geesome-wallet-client/ethers/@ethersproject/providers/ws": "7.5.10",
     "geesome-wallet-client/web3-provider-engine/ws": "5.2.4",
     "elliptic": "6.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7356,7 +7356,7 @@ is-ssh@^1.3.0:
   dependencies:
     protocols "^2.0.1"
 
-is-stream@^1.0.1, is-stream@^1.1.0:
+is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
   integrity sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==
@@ -8941,20 +8941,12 @@ node-fetch-npm@^2.0.2:
     json-parse-better-errors "^1.0.0"
     safe-buffer "^5.1.1"
 
-node-fetch@^2.1.2, node-fetch@^2.5.0, node-fetch@^2.6.0, node-fetch@^2.6.1, node-fetch@^2.6.7:
+node-fetch@2.7.0, node-fetch@^2.1.2, node-fetch@^2.5.0, node-fetch@^2.6.0, node-fetch@^2.6.1, node-fetch@^2.6.7, node-fetch@~1.7.1:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
   integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
   dependencies:
     whatwg-url "^5.0.0"
-
-node-fetch@~1.7.1:
-  version "1.7.3"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
-  integrity sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==
-  dependencies:
-    encoding "^0.1.11"
-    is-stream "^1.0.1"
 
 node-forge@^0.10.0:
   version "0.10.0"


### PR DESCRIPTION
Summary
- closes #138
- adds Yarn resolutions for the wallet `fetch-ponyfill > node-fetch` chain
- refreshes `yarn.lock` so `node-fetch@~1.7.1` resolves to patched `node-fetch@2.7.0`
- removes the vulnerable `node-fetch@1.7.3` lockfile entry

Verification
- `yarn install`
- `yarn why node-fetch`
- `yarn audit --groups dependencies --level high --json | node -e '<targeted parser for node-fetch/form-data/protobufjs/node-forge/ip/hoek>'`
- `node --import tsx --experimental-global-customevent ./node_modules/.bin/mocha test/ethereum.test.ts`
- `node --import tsx --experimental-global-customevent -e "await import('./src/web3Manager.ts'); await import('./src/ethereum.ts'); console.log('wallet import smoke ok')"`
- `git diff --check`

Notes
- Full `npm test` is still blocked in this local environment by missing native `node-datachannel` binary: `Cannot find module '../../../build/Release/node_datachannel.node'`.
- The targeted audit no longer reports `node-fetch`; remaining named dependency advisories are in the `node-forge`, `protobufjs`, `form-data`, and `hoek` chains.
