### PR TITLE
Patch wallet request form-data chain

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,8 @@
     "geesome-wallet-client/**/follow-redirects": "1.16.0",
     "geesome-wallet-client/**/fetch-ponyfill/node-fetch": "2.7.0",
     "fetch-ponyfill/node-fetch": "2.7.0",
+    "geesome-wallet-client/**/request/form-data": "2.5.5",
+    "request/form-data": "2.5.5",
     "geesome-wallet-client/ethers/@ethersproject/providers/ws": "7.5.10",
     "geesome-wallet-client/web3-provider-engine/ws": "5.2.4",
     "elliptic": "6.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4481,7 +4481,7 @@ columnify@^1.5.4:
     strip-ansi "^6.0.1"
     wcwidth "^1.0.0"
 
-combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
+combined-stream@^1.0.8, combined-stream@~1.0.6:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
@@ -6103,6 +6103,18 @@ forever-agent@~0.6.1:
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
   integrity sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==
 
+form-data@2.5.5, form-data@~2.3.2:
+  version "2.5.5"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.5.5.tgz#a5f6364ad7e4e67e95b4a07e2d8c6f711c74f624"
+  integrity sha512-jqdObeR2rxZZbPSGL+3VckHMYtu+f9//KXBsVny6JSX/pa38Fy+bGjuG8eW/H6USNQWhLi8Num++cU2yOCNz4A==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    es-set-tostringtag "^2.1.0"
+    hasown "^2.0.2"
+    mime-types "^2.1.35"
+    safe-buffer "^5.2.1"
+
 form-data@^4.0.5:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.5.tgz#b49e48858045ff4cbf6b03e1805cebcad3679053"
@@ -6112,15 +6124,6 @@ form-data@^4.0.5:
     combined-stream "^1.0.8"
     es-set-tostringtag "^2.1.0"
     hasown "^2.0.2"
-    mime-types "^2.1.12"
-
-form-data@~2.3.2:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.3.tgz#dcce52c05f644f298c6a7ab936bd724ceffbf3a6"
-  integrity sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==
-  dependencies:
-    asynckit "^0.4.0"
-    combined-stream "^1.0.6"
     mime-types "^2.1.12"
 
 fragment-cache@^0.2.1:
@@ -8531,7 +8534,7 @@ mime-db@1.52.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
   integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
 
-mime-types@^2.1.12, mime-types@~2.1.19:
+mime-types@^2.1.12, mime-types@^2.1.35, mime-types@~2.1.19:
   version "2.1.35"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
   integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==


### PR DESCRIPTION
Summary
- closes #140
- adds Yarn resolutions for the wallet `request > form-data` chain
- refreshes `yarn.lock` so `form-data@~2.3.2` resolves to patched `form-data@2.5.5`
- removes the vulnerable `form-data@2.3.3` lockfile entry

Verification
- `yarn install`
- `yarn why form-data`
- `yarn audit --groups dependencies --level high --json | node -e '<targeted parser for form-data/node-forge/protobufjs/ip/hoek>'`
- `node --import tsx --experimental-global-customevent ./node_modules/.bin/mocha test/ethereum.test.ts`
- `node --import tsx --experimental-global-customevent -e "await import('./src/web3Manager.ts'); await import('./src/ethereum.ts'); console.log('wallet import smoke ok')"`
- `git diff --check`

Notes
- Targeted audit no longer reports `form-data`; remaining named dependency advisories are in the `node-forge`, `protobufjs`, and `hoek` chains.
- Full `npm test` is still blocked in this local environment by missing native `node-datachannel` binary: `Cannot find module '../../../build/Release/node_datachannel.node'`.
