### PR TITLE
fix(storage): remove per-file directory add logging

### DIFF
--- a/src/JsIpfsServiceNode.ts
+++ b/src/JsIpfsServiceNode.ts
@@ -35,7 +35,6 @@ export default class JsIpfsServiceNode extends JsIpfsService {
       if (!file.path || file.path === path || file.path === trim(path, '/')) {
         res = file;
       }
-      console.log('addAll path', path, 'file', file)
     }
     const dirResult = this.wrapIpfsItem(res);
     const pinPromise = this.addPin(dirResult.id);


### PR DESCRIPTION
## Summary

- Remove the unconditional per-file `saveDirectory` console log from the Node IPFS storage service.
- Keep large directory adds from flooding downstream test/runtime logs when frontend bundles or restored data are stored.

## Validation

- `npm test` is blocked in this local checkout before tests run by the existing missing native binding: `Cannot find module ../../../build/Release/node_datachannel.node`.\n- Downstream `geesome-node` Docker suite passed with this commit pinned: `172 passing`, `11 pending`.