### PR TITLE
[codex] Use crypto randomness for generated codes

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -11,6 +11,7 @@ import _ from "lodash";
 import {v4 as uuidv4} from 'uuid';
 import stableSort from 'stable';
 import createHash from 'create-hash';
+import {randomInt} from 'node:crypto';
 import bip39 from "ethereum-cryptography/bip39";
 import englishWords from "ethereum-cryptography/bip39/wordlists/english";
 const {isNaN, isString, isObject, isUndefined, isArray, startsWith, last, trim} = _;
@@ -91,7 +92,7 @@ const makeCode = (length) => {
   let chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
   let res = '';
   for (let i = 0; i < length; i++) {
-    res += chars.charAt(Math.floor(Math.random() * chars.length));
+    res += chars.charAt(randomInt(chars.length));
   }
   return res;
 };

--- a/test/helpers.test.ts
+++ b/test/helpers.test.ts
@@ -25,6 +25,16 @@ describe('helpers', function () {
         done();
     });
 
+    it('makeCode should return requested-length base62 codes', function () {
+        const seenCodes = new Set<string>();
+        for (let i = 0; i < 20; i++) {
+            const code = commonHelper.makeCode(16);
+            expect(code).to.match(/^[A-Za-z0-9]{16}$/);
+            expect(seenCodes.has(code)).to.equal(false);
+            seenCodes.add(code);
+        }
+    });
+
     it('use hash to encrypt', function (done) {
         const hash = commonHelper.hash("58a9149c-7575-444d-9809-b69fe040239e");
         expect(hash).to.equal("87a339fe13f761473b6e84e707692a14149eb6092222552aa5ca660d38df8dd6");


### PR DESCRIPTION
## Summary

- changes `commonHelper.makeCode(length)` to use `node:crypto.randomInt()` instead of `Math.random()`
- preserves the existing helper signature and base62 alphabet
- adds a focused helper test for generated code length, alphabet, and sample uniqueness

Closes #151

## Verification

- `node --import tsx --experimental-global-customevent ./node_modules/.bin/mocha test/helpers.test.ts`: 3 passing
- `npm test`: blocked before helper tests by missing native `node-datachannel` module in this checkout: `Cannot find module '../../../build/Release/node_datachannel.node'`
