### PR TITLE
Add verifiable chat device fingerprints

### DIFF
--- a/src/browserE2eeHelper.ts
+++ b/src/browserE2eeHelper.ts
@@ -14,12 +14,14 @@ import {
 } from '@hpke/core';
 
 const DEVICE_KEYS_VERSION = 'geesome-device-keys-v1';
+const DEVICE_FINGERPRINT_VERSION = 'geesome-device-fingerprint-v1';
 const DEVICE_RECOVERY_VERSION = 'geesome-device-recovery-v1';
 const ENVELOPE_VERSION = 'geesome-e2ee-v2';
 const ATTACHMENT_VERSION = 'geesome-e2ee-attachment-v1';
 const ENVELOPE_TYPE = 'geesome.chat.message';
 const CONTENT_ALGORITHM = 'AES-256-GCM';
 const SIGNATURE_ALGORITHM = 'ECDSA-P256-SHA256';
+const FINGERPRINT_ALGORITHM = 'SHA-256';
 const KEY_WRAP_ALGORITHM = 'HPKE-DHKEM-P256-HKDF-SHA256-AES128GCM';
 const RECOVERY_KDF_ALGORITHM = 'PBKDF2-SHA256';
 const RECOVERY_CIPHER_ALGORITHM = 'AES-256-GCM';
@@ -107,6 +109,26 @@ function decodeBase64Url(value: string): Uint8Array {
   }
 
   return new Uint8Array(output);
+}
+
+function formatDeviceFingerprint(keyId: string): string {
+  let bytes;
+  try {
+    bytes = decodeBase64Url(keyId);
+  } catch {
+    throw new Error('device_key_id_invalid');
+  }
+  if (bytes.length !== 32) {
+    throw new Error('device_key_id_invalid');
+  }
+  const hex = Array.from(bytes)
+    .map(value => value.toString(16).padStart(2, '0').toUpperCase())
+    .join('');
+  const groups = hex.match(/.{4}/g);
+  if (!groups) {
+    throw new Error('device_key_id_invalid');
+  }
+  return groups.join(' ');
 }
 
 function canonicalize(value) {
@@ -679,6 +701,20 @@ const browserE2eeHelper = {
     }
   },
 
+  async getDeviceFingerprint(bundle) {
+    if (!await browserE2eeHelper.verifyDeviceKeyBundle(bundle)) {
+      throw new Error('device_bundle_invalid');
+    }
+    return {
+      version: DEVICE_FINGERPRINT_VERSION,
+      algorithm: FINGERPRINT_ALGORITHM,
+      ownerId: bundle.ownerId,
+      deviceId: bundle.deviceId,
+      keyId: bundle.keyId,
+      value: formatDeviceFingerprint(bundle.keyId)
+    };
+  },
+
   async encryptEnvelope(plaintext, recipients, senderKeys, options: any = {}) {
     if (!Array.isArray(recipients) || recipients.length === 0) {
       throw new Error('recipients_required');
@@ -961,15 +997,18 @@ const browserE2eeHelper = {
 
   encodeBase64Url,
   decodeBase64Url,
+  formatDeviceFingerprint,
 
   constants: {
     DEVICE_KEYS_VERSION,
+    DEVICE_FINGERPRINT_VERSION,
     DEVICE_RECOVERY_VERSION,
     ENVELOPE_VERSION,
     ATTACHMENT_VERSION,
     ENVELOPE_TYPE,
     CONTENT_ALGORITHM,
     SIGNATURE_ALGORITHM,
+    FINGERPRINT_ALGORITHM,
     KEY_WRAP_ALGORITHM,
     RECOVERY_KDF_ALGORITHM,
     RECOVERY_CIPHER_ALGORITHM,

--- a/test/browserE2eeHelper.test.ts
+++ b/test/browserE2eeHelper.test.ts
@@ -33,9 +33,39 @@ describe('browserE2eeHelper', function () {
     expect(alice.recoveryBundle).to.equal(null);
     expect(await browserE2eeHelper.verifyDeviceKeyBundle(alice.publicBundle)).to.equal(true);
 
+    const fingerprint = await browserE2eeHelper.getDeviceFingerprint(alice.publicBundle);
+    expect(fingerprint).to.include({
+      version: browserE2eeHelper.constants.DEVICE_FINGERPRINT_VERSION,
+      algorithm: browserE2eeHelper.constants.FINGERPRINT_ALGORITHM,
+      ownerId: 'alice',
+      deviceId: 'alice-browser',
+      keyId: alice.publicBundle.keyId
+    });
+    expect(fingerprint.value).to.match(/^(?:[0-9A-F]{4} ){15}[0-9A-F]{4}$/);
+    expect(await browserE2eeHelper.getDeviceFingerprint(
+      JSON.parse(JSON.stringify(alice.publicBundle))
+    )).to.deep.equal(fingerprint);
+
     const tampered = JSON.parse(JSON.stringify(alice.publicBundle));
     tampered.ownerId = 'mallory';
     expect(await browserE2eeHelper.verifyDeviceKeyBundle(tampered)).to.equal(false);
+    await expectRejected(
+      browserE2eeHelper.getDeviceFingerprint(tampered),
+      'device_bundle_invalid'
+    );
+  });
+
+  it('formats a full deterministic device fingerprint', function () {
+    const keyId = browserE2eeHelper.encodeBase64Url(
+      Uint8Array.from({length: 32}, (_value, index) => index)
+    );
+    expect(browserE2eeHelper.formatDeviceFingerprint(keyId)).to.equal(
+      '0001 0203 0405 0607 0809 0A0B 0C0D 0E0F ' +
+      '1011 1213 1415 1617 1819 1A1B 1C1D 1E1F'
+    );
+    expect(() => browserE2eeHelper.formatDeviceFingerprint('short')).to.throw(
+      'device_key_id_invalid'
+    );
   });
 
   it('creates an encrypted recovery bundle and restores non-extractable device keys', async function () {


### PR DESCRIPTION
## Summary
- derive a versioned, human-readable fingerprint from the full signed device bundle identity hash
- verify the public device bundle before returning fingerprint metadata
- cover deterministic formatting, serialization stability, and tamper rejection

## Compatibility
- additive helper API only; existing device bundles, key IDs, envelopes, and ciphertext formats are unchanged
- fingerprints retain all 256 SHA-256 bits and are grouped only for readability

## Validation
- `node --import tsx --experimental-global-customevent ./node_modules/.bin/mocha test/browserE2eeHelper.test.ts` (12 passing)
- `git diff --check`
- full `npm test` was attempted after `npm install --ignore-scripts`; unrelated WebRTC tests cannot load the skipped native `node-datachannel` binary
- a normal clean `npm install` was also attempted but the legacy nested `bufferutil` source does not compile against Node 22/V8