### PR TITLE
Define private encrypted chat attachment references

### DIFF
--- a/src/browserE2eeHelper.ts
+++ b/src/browserE2eeHelper.ts
@@ -18,6 +18,8 @@ const DEVICE_FINGERPRINT_VERSION = 'geesome-device-fingerprint-v1';
 const DEVICE_RECOVERY_VERSION = 'geesome-device-recovery-v1';
 const ENVELOPE_VERSION = 'geesome-e2ee-v2';
 const ATTACHMENT_VERSION = 'geesome-e2ee-attachment-v1';
+const ATTACHMENT_REFERENCE_VERSION = 'geesome-e2ee-attachment-reference-v1';
+const CHAT_MESSAGE_PAYLOAD_VERSION = 'geesome-chat-message-v1';
 const ENVELOPE_TYPE = 'geesome.chat.message';
 const CONTENT_ALGORITHM = 'AES-256-GCM';
 const SIGNATURE_ALGORITHM = 'ECDSA-P256-SHA256';
@@ -29,6 +31,7 @@ const DEFAULT_RECOVERY_ITERATIONS = 600000;
 const MINIMUM_RECOVERY_ITERATIONS = 600000;
 const MAXIMUM_RECOVERY_ITERATIONS = 2000000;
 const MINIMUM_RECOVERY_PASSPHRASE_LENGTH = 12;
+const MAXIMUM_CHAT_ATTACHMENTS = 20;
 const HPKE_INFO = new TextEncoder().encode('geesome.chat.content-key.v1');
 const RECOVERY_KEY_CHECK_INFO = new TextEncoder().encode('geesome.chat.device-recovery-check.v1');
 const BASE64_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
@@ -949,6 +952,92 @@ const browserE2eeHelper = {
     };
   },
 
+  getAttachmentUploadData(attachment) {
+    assertEncryptedAttachment(attachment, true);
+    return typeof attachment.ciphertext === 'string'
+      ? decodeBase64Url(attachment.ciphertext)
+      : new Uint8Array(toUint8Array(attachment.ciphertext));
+  },
+
+  createAttachmentReference(storageId, attachment, key) {
+    requireString(storageId, 'attachment_storage_id_required');
+    assertEncryptedAttachment(attachment, false);
+    const keyBytes = toUint8Array(key);
+    if (keyBytes.length !== 32) {
+      throw new Error('attachment_key_must_be_32_bytes');
+    }
+    return {
+      version: ATTACHMENT_REFERENCE_VERSION,
+      storageId,
+      encryption: {
+        version: attachment.version,
+        algorithm: attachment.algorithm,
+        mimeType: attachment.mimeType,
+        name: attachment.name,
+        size: attachment.size,
+        iv: attachment.iv,
+        key: encodeBase64Url(keyBytes)
+      }
+    };
+  },
+
+  isAttachmentReference(value) {
+    try {
+      assertAttachmentReference(value);
+      return true;
+    } catch {
+      return false;
+    }
+  },
+
+  async decryptAttachmentReference(ciphertext, reference) {
+    assertAttachmentReference(reference);
+    return browserE2eeHelper.decryptAttachment(
+      {
+        ...reference.encryption,
+        key: undefined,
+        ciphertext
+      },
+      decodeBase64Url(reference.encryption.key)
+    );
+  },
+
+  createChatMessagePayload(text, attachments: any[] = []) {
+    if (typeof text !== 'string') {
+      throw new Error('chat_message_text_invalid');
+    }
+    assertAttachmentReferenceList(attachments);
+    if (text.length === 0 && attachments.length === 0) {
+      throw new Error('chat_message_content_required');
+    }
+    return {
+      version: CHAT_MESSAGE_PAYLOAD_VERSION,
+      text,
+      attachments: attachments.map(copyAttachmentReference)
+    };
+  },
+
+  isChatMessagePayload(value) {
+    try {
+      assertChatMessagePayload(value);
+      return true;
+    } catch {
+      return false;
+    }
+  },
+
+  getChatAttachmentStorageIds(payload) {
+    assertChatMessagePayload(payload);
+    return payload.attachments.map(attachment => attachment.storageId);
+  },
+
+  createChatMessageEnvelopeMetadata(payload) {
+    return {
+      kind: 'message',
+      attachmentStorageIds: browserE2eeHelper.getChatAttachmentStorageIds(payload)
+    };
+  },
+
   isDeviceRecoveryBundle(value) {
     try {
       assertDeviceRecoveryBundleShape(value);
@@ -1005,6 +1094,8 @@ const browserE2eeHelper = {
     DEVICE_RECOVERY_VERSION,
     ENVELOPE_VERSION,
     ATTACHMENT_VERSION,
+    ATTACHMENT_REFERENCE_VERSION,
+    CHAT_MESSAGE_PAYLOAD_VERSION,
     ENVELOPE_TYPE,
     CONTENT_ALGORITHM,
     SIGNATURE_ALGORITHM,
@@ -1013,8 +1104,106 @@ const browserE2eeHelper = {
     RECOVERY_KDF_ALGORITHM,
     RECOVERY_CIPHER_ALGORITHM,
     DEFAULT_RECOVERY_ITERATIONS,
-    MINIMUM_RECOVERY_ITERATIONS
+    MINIMUM_RECOVERY_ITERATIONS,
+    MAXIMUM_CHAT_ATTACHMENTS
   }
 };
+
+function assertEncryptedAttachment(attachment, requireCiphertext: boolean) {
+  if (
+    !attachment ||
+    attachment.version !== ATTACHMENT_VERSION ||
+    attachment.algorithm !== CONTENT_ALGORITHM ||
+    !hasNonEmptyString(attachment.mimeType) ||
+    !(attachment.name === null || hasNonEmptyString(attachment.name)) ||
+    !Number.isSafeInteger(attachment.size) ||
+    attachment.size < 0 ||
+    !hasNonEmptyString(attachment.iv)
+  ) {
+    throw new Error('encrypted_attachment_invalid');
+  }
+  let iv;
+  try {
+    iv = decodeBase64Url(attachment.iv);
+  } catch {
+    throw new Error('encrypted_attachment_invalid');
+  }
+  if (iv.length !== 12) {
+    throw new Error('encrypted_attachment_invalid');
+  }
+  if (requireCiphertext && attachment.ciphertext === undefined) {
+    throw new Error('attachment_ciphertext_required');
+  }
+  if (requireCiphertext) {
+    try {
+      const ciphertext = typeof attachment.ciphertext === 'string'
+        ? decodeBase64Url(attachment.ciphertext)
+        : toUint8Array(attachment.ciphertext);
+      if (ciphertext.length < 16) {
+        throw new Error('attachment_ciphertext_invalid');
+      }
+    } catch {
+      throw new Error('attachment_ciphertext_invalid');
+    }
+  }
+}
+
+function assertAttachmentReference(value) {
+  if (
+    !value ||
+    value.version !== ATTACHMENT_REFERENCE_VERSION ||
+    !hasNonEmptyString(value.storageId) ||
+    !value.encryption ||
+    !hasNonEmptyString(value.encryption.key) ||
+    value.encryption.ciphertext !== undefined
+  ) {
+    throw new Error('attachment_reference_invalid');
+  }
+  assertEncryptedAttachment(value.encryption, false);
+  let key;
+  try {
+    key = decodeBase64Url(value.encryption.key);
+  } catch {
+    throw new Error('attachment_reference_invalid');
+  }
+  if (key.length !== 32) {
+    throw new Error('attachment_reference_invalid');
+  }
+}
+
+function assertAttachmentReferenceList(attachments) {
+  if (
+    !Array.isArray(attachments) ||
+    attachments.length > MAXIMUM_CHAT_ATTACHMENTS
+  ) {
+    throw new Error('chat_message_attachments_invalid');
+  }
+  attachments.forEach(assertAttachmentReference);
+  const storageIds = attachments.map(attachment => attachment.storageId);
+  if (new Set(storageIds).size !== storageIds.length) {
+    throw new Error('chat_message_attachment_duplicate');
+  }
+}
+
+function assertChatMessagePayload(value) {
+  if (
+    !value ||
+    value.version !== CHAT_MESSAGE_PAYLOAD_VERSION ||
+    typeof value.text !== 'string'
+  ) {
+    throw new Error('chat_message_payload_invalid');
+  }
+  assertAttachmentReferenceList(value.attachments);
+  if (value.text.length === 0 && value.attachments.length === 0) {
+    throw new Error('chat_message_content_required');
+  }
+}
+
+function copyAttachmentReference(reference) {
+  return {
+    ...reference,
+    encryption: {...reference.encryption}
+  };
+}
 
 export default browserE2eeHelper;

--- a/test/browserE2eeHelper.test.ts
+++ b/test/browserE2eeHelper.test.ts
@@ -383,6 +383,98 @@ describe('browserE2eeHelper', function () {
       browserE2eeHelper.decryptAttachment(serialized, result.key)
     );
   });
+
+  it('separates attachment upload bytes from the private encrypted-message reference', async function () {
+    const sender = await createDevice('sender', 'sender-browser');
+    const alice = await createDevice('alice', 'alice-browser');
+    const plaintext = new TextEncoder().encode('private image bytes');
+    const encrypted = await browserE2eeHelper.encryptAttachment(plaintext, {
+      name: 'private-photo.jpg',
+      mimeType: 'image/jpeg',
+      key: new Uint8Array(32).fill(5),
+      iv: new Uint8Array(12).fill(6)
+    });
+    const uploadData = browserE2eeHelper.getAttachmentUploadData(encrypted.attachment);
+    const reference = browserE2eeHelper.createAttachmentReference(
+      'bafyattachment',
+      encrypted.attachment,
+      encrypted.key
+    );
+    const payload = browserE2eeHelper.createChatMessagePayload('photo', [reference]);
+    const envelope = await browserE2eeHelper.encryptEnvelope(
+      payload,
+      [alice.publicBundle],
+      sender,
+      {
+        messageId: 'message-attachment',
+        conversationId: 'conversation-attachment',
+        createdAt: '2026-07-28T00:06:00.000Z',
+        metadata: browserE2eeHelper.createChatMessageEnvelopeMetadata(payload),
+        contentKey: new Uint8Array(32).fill(7),
+        iv: new Uint8Array(12).fill(8)
+      }
+    );
+    const storedEnvelope = JSON.parse(JSON.stringify(envelope));
+
+    expect(reference).to.not.have.property('ciphertext');
+    expect(reference.encryption).to.not.have.property('ciphertext');
+    expect(browserE2eeHelper.isAttachmentReference(reference)).to.equal(true);
+    expect(browserE2eeHelper.isChatMessagePayload(payload)).to.equal(true);
+    expect(storedEnvelope.metadata.attachmentStorageIds).to.deep.equal(['bafyattachment']);
+    expect(JSON.stringify(storedEnvelope)).to.not.include('private-photo.jpg');
+    expect(JSON.stringify(storedEnvelope)).to.not.include('image/jpeg');
+    expect(JSON.stringify(storedEnvelope)).to.not.include(reference.encryption.key);
+
+    const decryptedPayload = await browserE2eeHelper.decryptEnvelopeJson(
+      storedEnvelope,
+      alice,
+      sender.publicBundle
+    );
+    expect(browserE2eeHelper.isChatMessagePayload(decryptedPayload)).to.equal(true);
+    expect(new TextDecoder().decode(
+      await browserE2eeHelper.decryptAttachmentReference(
+        uploadData,
+        decryptedPayload.attachments[0]
+      )
+    )).to.equal('private image bytes');
+  });
+
+  it('rejects invalid attachment references, duplicate storage IDs, and metadata tampering', async function () {
+    const encrypted = await browserE2eeHelper.encryptAttachment(
+      new TextEncoder().encode('authenticated attachment'),
+      {
+        name: 'document.txt',
+        mimeType: 'text/plain',
+        key: new Uint8Array(32).fill(2),
+        iv: new Uint8Array(12).fill(3)
+      }
+    );
+    const uploadData = browserE2eeHelper.getAttachmentUploadData(encrypted.attachment);
+    const reference = browserE2eeHelper.createAttachmentReference(
+      'bafyreference',
+      encrypted.attachment,
+      encrypted.key
+    );
+    const invalidKey = JSON.parse(JSON.stringify(reference));
+    invalidKey.encryption.key = browserE2eeHelper.encodeBase64Url(new Uint8Array(31));
+    const embeddedCiphertext = JSON.parse(JSON.stringify(reference));
+    embeddedCiphertext.encryption.ciphertext = 'not-allowed-in-reference';
+
+    expect(browserE2eeHelper.isAttachmentReference(invalidKey)).to.equal(false);
+    expect(browserE2eeHelper.isAttachmentReference(embeddedCiphertext)).to.equal(false);
+    expect(() => browserE2eeHelper.createChatMessagePayload('', []))
+      .to.throw('chat_message_content_required');
+    expect(() => browserE2eeHelper.createChatMessagePayload('duplicate', [
+      reference,
+      reference
+    ])).to.throw('chat_message_attachment_duplicate');
+
+    const tampered = JSON.parse(JSON.stringify(reference));
+    tampered.encryption.name = 'different.txt';
+    await expectRejected(
+      browserE2eeHelper.decryptAttachmentReference(uploadData, tampered)
+    );
+  });
 });
 
 async function expectRejected(promise, expectedMessage = null) {


### PR DESCRIPTION
## Summary
- separate encrypted attachment upload bytes from private attachment descriptors
- add versioned chat message payload and safe public envelope metadata helpers
- validate attachment references, limits, duplicate CIDs, and authenticated metadata before browser decryption

## Validation
- `node --import tsx --experimental-global-customevent ./node_modules/.bin/mocha test/browserE2eeHelper.test.ts` (14 passing)
- `git diff --check`

## Local tooling note
- `npm test` could not complete under local Node 22: a normal install fails while building the legacy transitive `keccak`, and `npm install --ignore-scripts` leaves the unrelated `node-datachannel` native module unavailable. The affected browser E2EE test file passes in full.