### PR TITLE
Mark encrypted attachment messages as JSON

### DIFF
--- a/src/browserE2eeHelper.ts
+++ b/src/browserE2eeHelper.ts
@@ -1033,7 +1033,7 @@ const browserE2eeHelper = {
 
   createChatMessageEnvelopeMetadata(payload) {
     return {
-      kind: 'message',
+      kind: 'json',
       attachmentStorageIds: browserE2eeHelper.getChatAttachmentStorageIds(payload)
     };
   },

--- a/test/browserE2eeHelper.test.ts
+++ b/test/browserE2eeHelper.test.ts
@@ -420,7 +420,10 @@ describe('browserE2eeHelper', function () {
     expect(reference.encryption).to.not.have.property('ciphertext');
     expect(browserE2eeHelper.isAttachmentReference(reference)).to.equal(true);
     expect(browserE2eeHelper.isChatMessagePayload(payload)).to.equal(true);
-    expect(storedEnvelope.metadata.attachmentStorageIds).to.deep.equal(['bafyattachment']);
+    expect(storedEnvelope.metadata).to.deep.equal({
+      kind: 'json',
+      attachmentStorageIds: ['bafyattachment']
+    });
     expect(JSON.stringify(storedEnvelope)).to.not.include('private-photo.jpg');
     expect(JSON.stringify(storedEnvelope)).to.not.include('image/jpeg');
     expect(JSON.stringify(storedEnvelope)).to.not.include(reference.encryption.key);


### PR DESCRIPTION
## Summary
- emit the server-supported `json` envelope metadata kind for versioned chat payloads
- lock the complete public metadata shape in the attachment privacy round-trip test

## Why
`geesome-node` accepts only `text`, `json`, or `binary` metadata kinds. The previous `message` value would cause attachment sends to fail envelope validation.

## Validation
- `node --import tsx --experimental-global-customevent ./node_modules/.bin/mocha test/browserE2eeHelper.test.ts` (14 passing)
- `git diff --check`