### PR TITLE
Frame private-group post envelopes in browser E2EE helpers

### DIFF
--- a/src/browserE2eeHelper.ts
+++ b/src/browserE2eeHelper.ts
@@ -20,7 +20,10 @@ const ENVELOPE_VERSION = 'geesome-e2ee-v2';
 const ATTACHMENT_VERSION = 'geesome-e2ee-attachment-v1';
 const ATTACHMENT_REFERENCE_VERSION = 'geesome-e2ee-attachment-reference-v1';
 const CHAT_MESSAGE_PAYLOAD_VERSION = 'geesome-chat-message-v1';
+const PRIVATE_GROUP_POST_PAYLOAD_VERSION = 'geesome-private-group-post-v1';
 const ENVELOPE_TYPE = 'geesome.chat.message';
+const PRIVATE_GROUP_POST_ENVELOPE_TYPE = 'geesome.private-group.post';
+const PRIVATE_GROUP_CONVERSATION_PREFIX = 'geesome.private-group:';
 const CONTENT_ALGORITHM = 'AES-256-GCM';
 const SIGNATURE_ALGORITHM = 'ECDSA-P256-SHA256';
 const FINGERPRINT_ALGORITHM = 'SHA-256';
@@ -1038,6 +1041,80 @@ const browserE2eeHelper = {
     };
   },
 
+  createPrivateGroupPostPayload(text, attachments: any[] = []) {
+    const chatPayload = browserE2eeHelper.createChatMessagePayload(text, attachments);
+    return {
+      ...chatPayload,
+      version: PRIVATE_GROUP_POST_PAYLOAD_VERSION,
+      kind: 'message'
+    };
+  },
+
+  isPrivateGroupPostPayload(value) {
+    try {
+      assertPrivateGroupPostPayload(value);
+      return true;
+    } catch {
+      return false;
+    }
+  },
+
+  getPrivateGroupPostAttachmentStorageIds(payload) {
+    assertPrivateGroupPostPayload(payload);
+    return payload.attachments.map(attachment => attachment.storageId);
+  },
+
+  createPrivateGroupPostEnvelopeMetadata(groupIdentity, membershipVersion, payload) {
+    return {
+      kind: 'private-group-post',
+      groupIdentity: requireString(groupIdentity, 'private_group_identity_required'),
+      membershipVersion: normalizePrivateGroupMembershipVersion(membershipVersion),
+      attachmentStorageIds: browserE2eeHelper.getPrivateGroupPostAttachmentStorageIds(payload)
+    };
+  },
+
+  createPrivateGroupPostEnvelopeOptions(
+    groupIdentity,
+    membershipVersion,
+    payload,
+    options: any = {}
+  ) {
+    const metadata = browserE2eeHelper.createPrivateGroupPostEnvelopeMetadata(
+      groupIdentity,
+      membershipVersion,
+      payload
+    );
+    return {
+      ...options,
+      type: PRIVATE_GROUP_POST_ENVELOPE_TYPE,
+      conversationId: formatPrivateGroupConversationId(metadata.groupIdentity),
+      metadata
+    };
+  },
+
+  isPrivateGroupPostEnvelopeMetadata(value) {
+    try {
+      assertPrivateGroupPostEnvelopeMetadata(value);
+      return true;
+    } catch {
+      return false;
+    }
+  },
+
+  isPrivateGroupPostEnvelope(value) {
+    if (
+      !browserE2eeHelper.isEncryptedEnvelope(value) ||
+      value.type !== PRIVATE_GROUP_POST_ENVELOPE_TYPE ||
+      value.encoding !== 'json' ||
+      !browserE2eeHelper.isPrivateGroupPostEnvelopeMetadata(value.metadata)
+    ) {
+      return false;
+    }
+    return value.conversationId === formatPrivateGroupConversationId(
+      value.metadata.groupIdentity
+    );
+  },
+
   isDeviceRecoveryBundle(value) {
     try {
       assertDeviceRecoveryBundleShape(value);
@@ -1096,7 +1173,10 @@ const browserE2eeHelper = {
     ATTACHMENT_VERSION,
     ATTACHMENT_REFERENCE_VERSION,
     CHAT_MESSAGE_PAYLOAD_VERSION,
+    PRIVATE_GROUP_POST_PAYLOAD_VERSION,
     ENVELOPE_TYPE,
+    PRIVATE_GROUP_POST_ENVELOPE_TYPE,
+    PRIVATE_GROUP_CONVERSATION_PREFIX,
     CONTENT_ALGORITHM,
     SIGNATURE_ALGORITHM,
     FINGERPRINT_ALGORITHM,
@@ -1197,6 +1277,69 @@ function assertChatMessagePayload(value) {
   if (value.text.length === 0 && value.attachments.length === 0) {
     throw new Error('chat_message_content_required');
   }
+}
+
+function assertPrivateGroupPostPayload(value) {
+  if (
+    !value ||
+    value.version !== PRIVATE_GROUP_POST_PAYLOAD_VERSION ||
+    value.kind !== 'message' ||
+    typeof value.text !== 'string'
+  ) {
+    throw new Error('private_group_post_payload_invalid');
+  }
+  assertAttachmentReferenceList(value.attachments);
+  if (value.text.length === 0 && value.attachments.length === 0) {
+    throw new Error('private_group_post_content_required');
+  }
+}
+
+function assertPrivateGroupPostEnvelopeMetadata(value) {
+  if (
+    !value ||
+    !hasExactKeys(value, [
+      'kind',
+      'groupIdentity',
+      'membershipVersion',
+      'attachmentStorageIds'
+    ]) ||
+    value.kind !== 'private-group-post' ||
+    !hasNonEmptyString(value.groupIdentity) ||
+    !Array.isArray(value.attachmentStorageIds) ||
+    value.attachmentStorageIds.length > MAXIMUM_CHAT_ATTACHMENTS ||
+    !hasUniqueStrings(value.attachmentStorageIds)
+  ) {
+    throw new Error('private_group_post_metadata_invalid');
+  }
+  normalizePrivateGroupMembershipVersion(value.membershipVersion);
+}
+
+function normalizePrivateGroupMembershipVersion(value): string {
+  if (
+    (typeof value !== 'string' && typeof value !== 'number') ||
+    (typeof value === 'number' && !Number.isSafeInteger(value)) ||
+    !/^[1-9][0-9]*$/.test(String(value))
+  ) {
+    throw new Error('private_group_membership_version_invalid');
+  }
+  return String(value);
+}
+
+function formatPrivateGroupConversationId(groupIdentity): string {
+  return `${PRIVATE_GROUP_CONVERSATION_PREFIX}${requireString(
+    groupIdentity,
+    'private_group_identity_required'
+  )}`;
+}
+
+function hasExactKeys(value, keys: string[]): boolean {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return false;
+  }
+  const actualKeys = Object.keys(value).sort();
+  const expectedKeys = [...keys].sort();
+  return actualKeys.length === expectedKeys.length &&
+    actualKeys.every((key, index) => key === expectedKeys[index]);
 }
 
 function copyAttachmentReference(reference) {

--- a/test/browserE2eeHelper.test.ts
+++ b/test/browserE2eeHelper.test.ts
@@ -478,6 +478,124 @@ describe('browserE2eeHelper', function () {
       browserE2eeHelper.decryptAttachmentReference(uploadData, tampered)
     );
   });
+
+  it('frames private-group posts with signed stable identity and membership metadata', async function () {
+    const sender = await createDevice('sender', 'sender-browser');
+    const recipient = await createDevice('recipient', 'recipient-browser');
+    const encrypted = await browserE2eeHelper.encryptAttachment(
+      new TextEncoder().encode('private group attachment'),
+      {
+        name: 'private.txt',
+        mimeType: 'text/plain',
+        key: new Uint8Array(32).fill(4),
+        iv: new Uint8Array(12).fill(5)
+      }
+    );
+    const reference = browserE2eeHelper.createAttachmentReference(
+      'bafyprivategroupattachment',
+      encrypted.attachment,
+      encrypted.key
+    );
+    const payload = browserE2eeHelper.createPrivateGroupPostPayload(
+      'private group message',
+      [reference]
+    );
+    const options = browserE2eeHelper.createPrivateGroupPostEnvelopeOptions(
+      'bafyprivategroupidentity',
+      '7',
+      payload,
+      {
+        messageId: 'private-group-message',
+        createdAt: '2026-07-31T00:00:00.000Z',
+        contentKey: new Uint8Array(32).fill(6),
+        iv: new Uint8Array(12).fill(7)
+      }
+    );
+    const envelope = await browserE2eeHelper.encryptEnvelope(
+      payload,
+      [recipient.publicBundle],
+      sender,
+      options
+    );
+
+    expect(browserE2eeHelper.isPrivateGroupPostPayload(payload)).to.equal(true);
+    expect(browserE2eeHelper.isPrivateGroupPostEnvelope(envelope)).to.equal(true);
+    expect(envelope.type).to.equal('geesome.private-group.post');
+    expect(envelope.conversationId).to.equal(
+      'geesome.private-group:bafyprivategroupidentity'
+    );
+    expect(envelope.metadata).to.deep.equal({
+      kind: 'private-group-post',
+      groupIdentity: 'bafyprivategroupidentity',
+      membershipVersion: '7',
+      attachmentStorageIds: ['bafyprivategroupattachment']
+    });
+    expect(JSON.stringify(envelope)).to.not.include('private group message');
+    expect(JSON.stringify(envelope)).to.not.include('private.txt');
+    expect(JSON.stringify(envelope)).to.not.include('text/plain');
+    expect(JSON.stringify(envelope)).to.not.include(reference.encryption.key);
+
+    const decrypted = await browserE2eeHelper.decryptEnvelopeJson(
+      envelope,
+      recipient,
+      sender.publicBundle
+    );
+    expect(browserE2eeHelper.isPrivateGroupPostPayload(decrypted)).to.equal(true);
+    expect(decrypted).to.deep.equal(payload);
+  });
+
+  it('rejects invalid or mismatched private-group envelope metadata', async function () {
+    const payload = browserE2eeHelper.createPrivateGroupPostPayload('message');
+
+    expect(() => browserE2eeHelper.createPrivateGroupPostEnvelopeOptions(
+      'group',
+      '0',
+      payload
+    )).to.throw('private_group_membership_version_invalid');
+    expect(browserE2eeHelper.isPrivateGroupPostPayload({
+      ...payload,
+      kind: 'unexpected'
+    })).to.equal(false);
+    expect(browserE2eeHelper.isPrivateGroupPostEnvelopeMetadata({
+      kind: 'private-group-post',
+      groupIdentity: 'group',
+      membershipVersion: '1',
+      attachmentStorageIds: ['same', 'same']
+    })).to.equal(false);
+    expect(browserE2eeHelper.isPrivateGroupPostEnvelopeMetadata({
+      kind: 'private-group-post',
+      groupIdentity: 'group',
+      membershipVersion: '1',
+      attachmentStorageIds: [],
+      text: 'visible by mistake'
+    })).to.equal(false);
+    expect(() => browserE2eeHelper.createPrivateGroupPostEnvelopeOptions(
+      'group',
+      Number.MAX_SAFE_INTEGER + 1,
+      payload
+    )).to.throw('private_group_membership_version_invalid');
+
+    const sender = await createDevice('sender', 'sender-browser');
+    const recipient = await createDevice('recipient', 'recipient-browser');
+    const envelope = await browserE2eeHelper.encryptEnvelope(
+      payload,
+      [recipient.publicBundle],
+      sender,
+      browserE2eeHelper.createPrivateGroupPostEnvelopeOptions(
+        'group',
+        '1',
+        payload
+      )
+    );
+    const mismatched = JSON.parse(JSON.stringify(envelope));
+    mismatched.metadata.groupIdentity = 'other-group';
+
+    expect(browserE2eeHelper.isPrivateGroupPostEnvelope(mismatched)).to.equal(false);
+    expect(await browserE2eeHelper.verifyEnvelopeSignature(
+      mismatched,
+      sender.publicBundle
+    )).to.equal(false);
+  });
 });
 
 async function expectRejected(promise, expectedMessage = null) {


### PR DESCRIPTION
## Summary

- add a versioned encrypted private-group post payload that reuses the existing attachment reference contract
- bind an opaque stable group identity, membership version, and attachment storage IDs into signed envelope metadata
- provide one envelope-options constructor so browser clients cannot accidentally mismatch the private-group conversation identity
- reject extra public metadata fields, duplicate attachment IDs, invalid versions, and mismatched conversation identities

## Why

GeeSome browser clients need one shared serialization contract before `geesome-node` can accept encrypted private-group posts. Keeping this framing in `geesome-libs` avoids separate node and UI protocol definitions while preserving the rule that message text, attachment names, MIME types, and attachment keys remain inside ciphertext.

This is additive and does not change existing direct-chat envelope behavior.

## Validation

- `npm test` (41 passing, 2 pending)
- direct `test/browserE2eeHelper.test.ts` run (16 passing)
- `git diff --check`